### PR TITLE
Add bumped version of jsdoc-to-markdown to fix dependabot issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dmd-clear": "^0.1.2",
     "eslint": "^5.16.0",
     "eslint-plugin-prettier": "^2.6.2",
-    "jsdoc-to-markdown": "^4.0.1",
+    "jsdoc-to-markdown": "^8.0.0",
     "mocha": "^5.2.0",
     "mongodb": "^3.2.5",
     "prebuild": "^7.6.2",


### PR DESCRIPTION
It turns out that jsdoc-to-markdown that is included here contains a dependency to jsdoc-api which in turn has a dependency on jsdoc. The version of jsdoc that is used in the version of jsdoc-api has a dependency on Taffy which is removed in the latest release.  So in order to address the below dependabot alert, we should use the latest version of jsdoc-to-markdown. I assume the package-lock will be updated by the bot, so I'm not making changes to it for now.

https://github.com/microsoft/ads-kerberos/security/dependabot/49